### PR TITLE
Potential fix for code scanning alert no. 110: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/neuralegion.yml
+++ b/.github/workflows/neuralegion.yml
@@ -160,6 +160,8 @@ on:
 jobs:
   neuralegion_scan:
     runs-on: ubuntu-18.04
+    permissions:
+      contents: read
     name: A job to run a Nexploit scan
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/nuxt-gtm-up/security/code-scanning/110](https://github.com/deadjdona/nuxt-gtm-up/security/code-scanning/110)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves running a scan and does not appear to require write access, we will set the permissions to `contents: read`. This ensures that the workflow has the minimal permissions necessary to operate securely.

The `permissions` block will be added at the job level (`neuralegion_scan`) to limit its scope to this specific job. If additional permissions are required in the future, they can be explicitly added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
