### PR TITLE
Potential fix for code scanning alert no. 109: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/nuxt-gtm-up/security/code-scanning/109](https://github.com/deadjdona/nuxt-gtm-up/security/code-scanning/109)

To fix the issue, we need to add a `permissions` block to the workflow file. Since this is a basic CI workflow for linting, it only requires read access to the repository contents. The `permissions` block should be added at the root level of the workflow file to apply to all jobs within the workflow. This ensures that the `GITHUB_TOKEN` used by the workflow has the minimal permissions required (`contents: read`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
