### PR TITLE
Potential fix for code scanning alert no. 108: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,5 +1,8 @@
 name: Test Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/nuxt-gtm-up/security/code-scanning/108](https://github.com/deadjdona/nuxt-gtm-up/security/code-scanning/108)

To fix the issue, we need to add a `permissions` block to the workflow. Since this is a CI build process, the workflow likely only requires read access to the repository contents. We will set `contents: read` at the workflow level to apply minimal permissions to all jobs. This ensures that the `GITHUB_TOKEN` does not have unnecessary write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
