### PR TITLE
Potential fix for code scanning alert no. 107: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lib-publish.yml
+++ b/.github/workflows/lib-publish.yml
@@ -9,6 +9,10 @@ on:
   #   paths:
   #     - ".github/workflows/lib-publish.yml"
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   lib-publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/nuxt-gtm-up/security/code-scanning/107](https://github.com/deadjdona/nuxt-gtm-up/security/code-scanning/107)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for accessing the repository's contents during the `actions/checkout@v3` step.
- `packages: write` for publishing the package to the npm registry.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
